### PR TITLE
Invite-link sharing with optional anonymous claims

### DIFF
--- a/backend/__tests__/helpers/testApp.js
+++ b/backend/__tests__/helpers/testApp.js
@@ -51,6 +51,7 @@ function createTestApp() {
   const sharingRoutes = require('../../routes/sharing');
   const adminRoutes = require('../../routes/admin');
   const listRoutes = require('../../routes/lists');
+  const publicRoutes = require('../../routes/public');
 
   // Health check endpoint
   app.get('/health', (req, res) => {
@@ -59,6 +60,7 @@ function createTestApp() {
 
   // Mount routes
   app.use('/api/auth', authRoutes);
+  app.use('/api/public', publicRoutes);
   app.use('/api/wishlist', requireAuth, wishlistRoutes);
   app.use('/api', requireAuth, sharingRoutes);
   app.use('/api/admin', requireAuth, adminRoutes);

--- a/backend/__tests__/integration/invite-links.test.js
+++ b/backend/__tests__/integration/invite-links.test.js
@@ -1,0 +1,403 @@
+const supertest = require('supertest');
+const { loginAs, createUnauthenticatedRequest } = require('../helpers/auth');
+const { createTestUsers } = require('../fixtures/users');
+const { createWishlistWithItems } = require('../fixtures/wishlists');
+const Wishlist = require('../../models/Wishlist');
+
+describe('Invite Link Sharing', () => {
+  let alice, bob, charlie;
+
+  beforeEach(async () => {
+    const users = await createTestUsers();
+    alice = users.alice;
+    bob = users.bob;
+    charlie = users.charlie;
+  });
+
+  describe('Token Generation', () => {
+    it('should generate an invite link for a list', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      const res = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      expect(res.body.token).toBeDefined();
+      expect(res.body.token.length).toBe(64);
+      expect(res.body.link).toContain(res.body.token);
+    });
+
+    it('should regenerate a different token', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      const res1 = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const res2 = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      expect(res1.body.token).not.toBe(res2.body.token);
+    });
+
+    it('should only allow the owner to generate tokens', async () => {
+      const wishlist = await createWishlistWithItems(alice, [], {
+        sharedWith: [bob._id]
+      });
+      const agent = await loginAs(bob);
+
+      await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(404);
+    });
+
+    it('should return invite link status', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      // Initially no link
+      const res1 = await agent
+        .get(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+      expect(res1.body.enabled).toBe(false);
+      expect(res1.body.token).toBeNull();
+
+      // After generating
+      await agent.post(`/api/share/${wishlist._id}/invite-link`);
+      const res2 = await agent
+        .get(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+      expect(res2.body.enabled).toBe(true);
+      expect(res2.body.token).toBeDefined();
+    });
+  });
+
+  describe('Disable Invite Link', () => {
+    it('should disable an invite link', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      const genRes = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      await agent
+        .delete(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      // Public access should fail
+      const { request } = createUnauthenticatedRequest();
+      await request
+        .get(`/api/public/invite/${genRes.body.token}`)
+        .expect(404);
+    });
+  });
+
+  describe('Public Access', () => {
+    it('should return list data for a valid token', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      const genRes = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const { request } = createUnauthenticatedRequest();
+      const res = await request
+        .get(`/api/public/invite/${genRes.body.token}`)
+        .expect(200);
+
+      expect(res.body.list.name).toBe(wishlist.name);
+      expect(res.body.list.owner.name).toBe(alice.name);
+      // Should not expose owner email
+      expect(res.body.list.owner.email).toBeUndefined();
+      expect(res.body.items.length).toBe(2);
+    });
+
+    it('should return 404 for invalid token', async () => {
+      const { request } = createUnauthenticatedRequest();
+      await request
+        .get('/api/public/invite/invalidtoken123')
+        .expect(404);
+    });
+
+    it('should expose claimer name and picture in public response', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Item 1', price: 10 }
+      ], { sharedWith: [bob._id] });
+      const agent = await loginAs(alice);
+
+      // Generate invite link
+      const genRes = await agent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      // Bob claims an item
+      const bobAgent = await loginAs(bob);
+      const itemId = wishlist.items[0]._id;
+      await bobAgent
+        .post(`/api/share/claim/${wishlist._id}/${itemId}`)
+        .expect(200);
+
+      // Public view shows the claimer's identity so others can coordinate
+      const { request } = createUnauthenticatedRequest();
+      const res = await request
+        .get(`/api/public/invite/${genRes.body.token}`)
+        .expect(200);
+
+      const item = res.body.items[0];
+      expect(item.isClaimed).toBe(true);
+      expect(item.status?.claimedBy?.name).toBe(bob.name);
+      expect(item.isAnonymousClaim).toBe(false);
+    });
+  });
+
+  describe('Join via Invite', () => {
+    it('should add authenticated user to sharedWith', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const bobAgent = await loginAs(bob);
+      const joinRes = await bobAgent
+        .post(`/api/public/invite/${genRes.body.token}/join`)
+        .expect(200);
+
+      expect(joinRes.body.listId).toBeDefined();
+
+      // Verify bob is now in sharedWith
+      const updated = await Wishlist.findById(wishlist._id);
+      expect(updated.sharedWith.map(id => id.toString())).toContain(bob._id.toString());
+    });
+
+    it('should return 401 for unauthenticated join', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const { request } = createUnauthenticatedRequest();
+      await request
+        .post(`/api/public/invite/${genRes.body.token}/join`)
+        .expect(401);
+    });
+
+    it('should not duplicate user in sharedWith', async () => {
+      const wishlist = await createWishlistWithItems(alice, [], {
+        sharedWith: [bob._id]
+      });
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const bobAgent = await loginAs(bob);
+      await bobAgent
+        .post(`/api/public/invite/${genRes.body.token}/join`)
+        .expect(200);
+
+      const updated = await Wishlist.findById(wishlist._id);
+      const bobEntries = updated.sharedWith.filter(id => id.toString() === bob._id.toString());
+      expect(bobEntries.length).toBe(1);
+    });
+
+    it('should not let owner join their own list', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      await aliceAgent
+        .post(`/api/public/invite/${genRes.body.token}/join`)
+        .expect(400);
+    });
+  });
+
+  describe('Anonymous Claims', () => {
+    it('should allow anonymous claim when enabled', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ]);
+      const aliceAgent = await loginAs(alice);
+
+      // Generate link and enable anonymous claims
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      await aliceAgent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: true })
+        .expect(200);
+
+      // Anonymous claim
+      const { request } = createUnauthenticatedRequest();
+      const res = await request
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .send({ claimerName: 'John' })
+        .expect(200);
+
+      expect(res.body.isClaimed).toBe(true);
+      expect(res.body.status?.claimedBy?.name).toBe('John');
+      expect(res.body.isAnonymousClaim).toBe(true);
+    });
+
+    it('should reject anonymous claim when disabled', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ]);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      // Anonymous claims not enabled (default is false)
+      const { request } = createUnauthenticatedRequest();
+      await request
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .send({ claimerName: 'John' })
+        .expect(401);
+    });
+
+    it('should require claimer name for anonymous claims', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ]);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      await aliceAgent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: true })
+        .expect(200);
+
+      const { request } = createUnauthenticatedRequest();
+      await request
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .send({})
+        .expect(400);
+    });
+
+    it('should prevent claiming already-claimed items', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ]);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      await aliceAgent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: true })
+        .expect(200);
+
+      const { request: req1 } = createUnauthenticatedRequest();
+      await req1
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .send({ claimerName: 'John' })
+        .expect(200);
+
+      const { request: req2 } = createUnauthenticatedRequest();
+      await req2
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .send({ claimerName: 'Jane' })
+        .expect(400);
+    });
+  });
+
+  describe('Authenticated Claims via Invite', () => {
+    it('should auto-join user when claiming via invite link', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ]);
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      // Bob claims without being in sharedWith - should auto-join
+      const bobAgent = await loginAs(bob);
+      await bobAgent
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .expect(200);
+
+      // Verify bob was added to sharedWith
+      const updated = await Wishlist.findById(wishlist._id);
+      expect(updated.sharedWith.map(id => id.toString())).toContain(bob._id.toString());
+    });
+
+    it('should allow authenticated user to toggle claim', async () => {
+      const wishlist = await createWishlistWithItems(alice, [
+        { title: 'Test Item', price: 25 }
+      ], { sharedWith: [bob._id] });
+      const aliceAgent = await loginAs(alice);
+
+      const genRes = await aliceAgent
+        .post(`/api/share/${wishlist._id}/invite-link`)
+        .expect(200);
+
+      const bobAgent = await loginAs(bob);
+
+      // Claim
+      const claimRes = await bobAgent
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .expect(200);
+      expect(claimRes.body.isClaimed).toBe(true);
+
+      // Unclaim
+      const unclaimRes = await bobAgent
+        .post(`/api/public/invite/${genRes.body.token}/claim/${wishlist.items[0]._id}`)
+        .expect(200);
+      expect(unclaimRes.body.isClaimed).toBe(false);
+    });
+  });
+
+  describe('Anonymous Claims Toggle', () => {
+    it('should toggle anonymous claims setting', async () => {
+      const wishlist = await createWishlistWithItems(alice);
+      const agent = await loginAs(alice);
+
+      const res1 = await agent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: true })
+        .expect(200);
+      expect(res1.body.allowAnonymousClaims).toBe(true);
+
+      const res2 = await agent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: false })
+        .expect(200);
+      expect(res2.body.allowAnonymousClaims).toBe(false);
+    });
+
+    it('should only allow owner to toggle anonymous claims', async () => {
+      const wishlist = await createWishlistWithItems(alice, [], {
+        sharedWith: [bob._id]
+      });
+      const agent = await loginAs(bob);
+
+      await agent
+        .put(`/api/share/${wishlist._id}/anonymous-claims`)
+        .send({ allow: true })
+        .expect(404);
+    });
+  });
+});

--- a/backend/models/Wishlist.js
+++ b/backend/models/Wishlist.js
@@ -22,6 +22,20 @@ const wishlistSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User'
   }],
+  inviteToken: {
+    type: String,
+    unique: true,
+    sparse: true,
+    index: true
+  },
+  inviteLinkEnabled: {
+    type: Boolean,
+    default: false
+  },
+  allowAnonymousClaims: {
+    type: Boolean,
+    default: false
+  },
   items: [{
     title: {
       type: String,
@@ -46,7 +60,12 @@ const wishlistSchema = new mongoose.Schema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User'
       },
-      claimedAt: Date
+      claimedAt: Date,
+      anonymousClaimerName: String,
+      isAnonymousClaim: {
+        type: Boolean,
+        default: false
+      }
     }
   }]
 });

--- a/backend/routes/public.js
+++ b/backend/routes/public.js
@@ -1,0 +1,231 @@
+const express = require('express');
+const router = express.Router();
+const Wishlist = require('../models/Wishlist');
+
+// GET /api/public/invite/:token - View list via invite link (no auth required)
+router.get('/invite/:token', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      inviteToken: req.params.token,
+      inviteLinkEnabled: true
+    })
+      .populate('user', 'name picture')
+      .populate('items.status.claimedBy', 'name picture');
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'Invite link not found or disabled' });
+    }
+
+    // Check if the current user (if authenticated) is already in sharedWith
+    const isAuthenticated = req.isAuthenticated && req.isAuthenticated();
+    const currentUserId = isAuthenticated ? req.user._id.toString() : null;
+    const isOwner = currentUserId && wishlist.user._id.toString() === currentUserId;
+    const isSharedWith = currentUserId && wishlist.sharedWith.some(
+      id => id.toString() === currentUserId
+    );
+
+    // Build a privacy-safe response. Shape items like the authed shared view
+    // (status.claimedBy populated) so the frontend can reuse WishlistItem.
+    // Hide identity of authed claimers — anonymous claimers expose their typed name.
+    const items = wishlist.items.map(item => {
+      const isAnon = !!item.status?.isAnonymousClaim;
+      const hasAuthedClaim = !!item.status?.claimedBy;
+      const isClaimed = isAnon || hasAuthedClaim;
+
+      let claimedBy = null;
+      if (isAnon) {
+        claimedBy = { _id: `anon-${item._id}`, name: item.status.anonymousClaimerName, picture: null };
+      } else if (hasAuthedClaim) {
+        claimedBy = {
+          _id: item.status.claimedBy._id,
+          name: item.status.claimedBy.name,
+          picture: item.status.claimedBy.picture
+        };
+      }
+
+      return {
+        _id: item._id,
+        title: item.title,
+        description: item.description,
+        link: item.link,
+        imageUrl: item.imageUrl,
+        notes: item.notes,
+        price: item.price,
+        priority: item.priority,
+        status: claimedBy ? { claimedBy, claimedAt: item.status?.claimedAt } : {},
+        isClaimed,
+        isAnonymousClaim: isAnon
+      };
+    });
+
+    res.json({
+      list: {
+        _id: wishlist._id,
+        name: wishlist.name,
+        description: wishlist.description,
+        event_date: wishlist.event_date,
+        owner: {
+          name: wishlist.user.name,
+          picture: wishlist.user.picture
+        },
+        allowAnonymousClaims: wishlist.allowAnonymousClaims
+      },
+      items,
+      viewer: {
+        isAuthenticated,
+        isOwner,
+        isSharedWith
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching public list:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// POST /api/public/invite/:token/join - Join list via invite link (auth required)
+router.post('/invite/:token/join', async (req, res) => {
+  try {
+    if (!req.isAuthenticated || !req.isAuthenticated()) {
+      return res.status(401).json({ message: 'Sign in to join this list' });
+    }
+
+    const wishlist = await Wishlist.findOne({
+      inviteToken: req.params.token,
+      inviteLinkEnabled: true
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'Invite link not found or disabled' });
+    }
+
+    // Don't let the owner join their own list
+    if (wishlist.user.toString() === req.user._id.toString()) {
+      return res.status(400).json({ message: 'You own this list' });
+    }
+
+    // Check if already in sharedWith
+    const alreadyShared = wishlist.sharedWith.some(
+      id => id.toString() === req.user._id.toString()
+    );
+
+    if (!alreadyShared) {
+      wishlist.sharedWith.push(req.user._id);
+      await wishlist.save();
+    }
+
+    res.json({ message: 'Successfully joined list', listId: wishlist._id });
+  } catch (error) {
+    console.error('Error joining list:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// POST /api/public/invite/:token/claim/:itemId - Claim item via invite link
+router.post('/invite/:token/claim/:itemId', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      inviteToken: req.params.token,
+      inviteLinkEnabled: true
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'Invite link not found or disabled' });
+    }
+
+    const item = wishlist.items.id(req.params.itemId);
+    if (!item) {
+      return res.status(404).json({ message: 'Item not found' });
+    }
+
+    const isAuthenticated = req.isAuthenticated && req.isAuthenticated();
+
+    if (isAuthenticated) {
+      // Authenticated claim flow
+      const userId = req.user._id;
+
+      // Don't let owner claim their own items
+      if (wishlist.user.toString() === userId.toString()) {
+        return res.status(400).json({ message: 'Cannot claim items on your own list' });
+      }
+
+      // If item is already claimed by someone else, prevent claiming
+      if (item.status?.claimedBy && item.status.claimedBy.toString() !== userId.toString()) {
+        return res.status(400).json({ message: 'Item already claimed by someone else' });
+      }
+      if (item.status?.isAnonymousClaim) {
+        return res.status(400).json({ message: 'Item already claimed' });
+      }
+
+      // Auto-join if not already in sharedWith
+      const alreadyShared = wishlist.sharedWith.some(
+        id => id.toString() === userId.toString()
+      );
+      if (!alreadyShared) {
+        wishlist.sharedWith.push(userId);
+      }
+
+      // Toggle claim
+      if (item.status?.claimedBy?.toString() === userId.toString()) {
+        item.status = {};
+      } else {
+        item.status = {
+          claimedBy: userId,
+          claimedAt: new Date()
+        };
+      }
+    } else {
+      // Anonymous claim flow
+      if (!wishlist.allowAnonymousClaims) {
+        return res.status(401).json({ message: 'Sign in to claim items' });
+      }
+
+      const { claimerName } = req.body;
+      if (!claimerName || !claimerName.trim()) {
+        return res.status(400).json({ message: 'Name is required for anonymous claims' });
+      }
+
+      // Prevent claiming already-claimed items
+      if (item.status?.claimedBy || item.status?.isAnonymousClaim) {
+        return res.status(400).json({ message: 'Item already claimed' });
+      }
+
+      item.status = {
+        anonymousClaimerName: claimerName.trim(),
+        isAnonymousClaim: true,
+        claimedAt: new Date()
+      };
+    }
+
+    await wishlist.save();
+
+    // Return updated item in the same shape as the GET response
+    const isAnon = !!item.status?.isAnonymousClaim;
+    const hasAuthedClaim = !!item.status?.claimedBy;
+    const isClaimed = isAnon || hasAuthedClaim;
+
+    let claimedBy = null;
+    if (isAnon) {
+      claimedBy = { _id: `anon-${item._id}`, name: item.status.anonymousClaimerName, picture: null };
+    } else if (hasAuthedClaim) {
+      claimedBy = {
+        _id: req.user._id,
+        name: req.user.name,
+        picture: req.user.picture
+      };
+    }
+
+    res.json({
+      _id: item._id,
+      title: item.title,
+      status: claimedBy ? { claimedBy, claimedAt: item.status.claimedAt } : {},
+      isClaimed,
+      isAnonymousClaim: isAnon
+    });
+  } catch (error) {
+    console.error('Error claiming item:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/sharing.js
+++ b/backend/routes/sharing.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const crypto = require('crypto');
 const User = require('../models/User');
 const Wishlist = require('../models/Wishlist');
 const { sendEmail, getShareInviteEmail } = require('../utils/emailService');
@@ -223,6 +224,102 @@ router.post('/share/claim/:listId/:itemId', async (req, res) => {
     res.json(updatedItem);
   } catch (error) {
     console.error('Error claiming/unclaiming item:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Get invite link status
+router.get('/share/:listId/invite-link', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      _id: req.params.listId,
+      user: req.user._id
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'List not found' });
+    }
+
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost';
+    res.json({
+      enabled: wishlist.inviteLinkEnabled,
+      token: wishlist.inviteToken || null,
+      link: wishlist.inviteToken ? `${frontendUrl}/invite/${wishlist.inviteToken}` : null,
+      allowAnonymousClaims: wishlist.allowAnonymousClaims
+    });
+  } catch (error) {
+    console.error('Error getting invite link:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Generate or regenerate invite link
+router.post('/share/:listId/invite-link', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      _id: req.params.listId,
+      user: req.user._id
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'List not found' });
+    }
+
+    wishlist.inviteToken = crypto.randomBytes(32).toString('hex');
+    wishlist.inviteLinkEnabled = true;
+    await wishlist.save();
+
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost';
+    res.json({
+      token: wishlist.inviteToken,
+      link: `${frontendUrl}/invite/${wishlist.inviteToken}`
+    });
+  } catch (error) {
+    console.error('Error generating invite link:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Disable invite link
+router.delete('/share/:listId/invite-link', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      _id: req.params.listId,
+      user: req.user._id
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'List not found' });
+    }
+
+    wishlist.inviteLinkEnabled = false;
+    await wishlist.save();
+
+    res.json({ message: 'Invite link disabled' });
+  } catch (error) {
+    console.error('Error disabling invite link:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Toggle anonymous claims
+router.put('/share/:listId/anonymous-claims', async (req, res) => {
+  try {
+    const wishlist = await Wishlist.findOne({
+      _id: req.params.listId,
+      user: req.user._id
+    });
+
+    if (!wishlist) {
+      return res.status(404).json({ message: 'List not found' });
+    }
+
+    wishlist.allowAnonymousClaims = !!req.body.allow;
+    await wishlist.save();
+
+    res.json({ allowAnonymousClaims: wishlist.allowAnonymousClaims });
+  } catch (error) {
+    console.error('Error toggling anonymous claims:', error);
     res.status(500).json({ message: error.message });
   }
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,6 +34,7 @@ const wishlistRoutes = require('./routes/wishlist');
 const sharingRoutes = require('./routes/sharing');
 const adminRoutes = require('./routes/admin');
 const listRoutes = require('./routes/lists');
+const publicRoutes = require('./routes/public');
 
 // Health check endpoint for ALB - improved with connection checks
 app.get('/health', async (req, res) => {
@@ -144,6 +145,7 @@ const startServer = async () => {
 
     // Use routes - after all middleware is initialized
     app.use('/api/auth', authRoutes);
+    app.use('/api/public', publicRoutes);
     app.use('/api/wishlist', requireAuth, wishlistRoutes);
     app.use('/api', requireAuth, sharingRoutes);
     app.use('/api/admin', requireAuth, adminRoutes);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { Container, CssBaseline, ThemeProvider, CircularProgress, Box, alpha } from '@mui/material';
 import WishlistPage from './pages/WishlistPage';
 import LoginPage from './pages/LoginPage';
@@ -10,6 +10,7 @@ import SharedListsPage from './pages/SharedListsPage';
 import { ListProvider } from './contexts/ListContext';
 import ListsPage from './pages/ListsPage';
 import TermsOfServicePage from './pages/TermsOfServicePage';
+import InvitePage from './pages/InvitePage';
 
 const LoadingSpinner = () => (
   <Box
@@ -48,6 +49,24 @@ const ProtectedRoute = ({ children }) => {
   return children;
 };
 
+function PostLoginRedirect() {
+  const navigate = useNavigate();
+  const { getPostLoginRedirect } = useAuth();
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    if (!checked) {
+      const redirect = getPostLoginRedirect();
+      if (redirect) {
+        navigate(redirect, { replace: true });
+      }
+      setChecked(true);
+    }
+  }, [checked, getPostLoginRedirect, navigate]);
+
+  return null;
+}
+
 function AppContent() {
   const { user, loading } = useAuth();
 
@@ -81,6 +100,7 @@ function AppContent() {
             } : {},
           }}
         >
+          {user && <PostLoginRedirect />}
           {user && <Navbar />}
           <Container
             maxWidth="lg"
@@ -95,6 +115,7 @@ function AppContent() {
             <Routes>
               <Route path="/login" element={<LoginWrapper />} />
               <Route path="/terms" element={<TermsOfServicePage />} />
+              <Route path="/invite/:token" element={<InvitePage />} />
               <Route path="/" element={
                 <ProtectedRoute>
                   <ListsPage />

--- a/frontend/src/components/ShareListDialog.js
+++ b/frontend/src/components/ShareListDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -12,15 +12,31 @@ import {
   Alert,
   Avatar,
   Chip,
+  Divider,
+  Switch,
+  FormControlLabel,
+  Tooltip,
   alpha,
 } from '@mui/material';
 import {
   Delete as DeleteIcon,
   PersonAdd as PersonAddIcon,
   Schedule as ScheduleIcon,
+  Link as LinkIcon,
+  ContentCopy as CopyIcon,
+  Refresh as RefreshIcon,
+  LinkOff as LinkOffIcon,
 } from '@mui/icons-material';
 import { format } from 'date-fns';
-import { shareList, getSharedUsers, unshareList } from '../services/api';
+import {
+  shareList,
+  getSharedUsers,
+  unshareList,
+  getInviteLinkStatus,
+  generateInviteLink,
+  disableInviteLink,
+  setAnonymousClaims,
+} from '../services/api';
 import { useList } from '../contexts/ListContext';
 import { colors } from '../theme';
 
@@ -29,6 +45,11 @@ function ShareListDialog({ open, onClose, listId }) {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [sharedUsers, setSharedUsers] = useState([]);
+  const [inviteLink, setInviteLink] = useState(null);
+  const [inviteLinkEnabled, setInviteLinkEnabled] = useState(false);
+  const [allowAnonymous, setAllowAnonymous] = useState(false);
+  const inviteLinkInputRef = useRef(null);
+  const [copied, setCopied] = useState(false);
   const { currentList } = useList();
 
   useEffect(() => {
@@ -82,11 +103,98 @@ function ShareListDialog({ open, onClose, listId }) {
     }
   }, [listId]);
 
+  const loadInviteLinkStatus = useCallback(async () => {
+    if (!listId) return;
+    try {
+      const data = await getInviteLinkStatus(listId);
+      setInviteLinkEnabled(data.enabled);
+      setInviteLink(data.link);
+      setAllowAnonymous(data.allowAnonymousClaims);
+    } catch (error) {
+      console.error('Error loading invite link status:', error);
+    }
+  }, [listId]);
+
   useEffect(() => {
     if (open) {
+      setInviteLink(null);
+      setInviteLinkEnabled(false);
+      setAllowAnonymous(false);
+      setCopied(false);
       loadSharedUsers();
+      loadInviteLinkStatus();
     }
-  }, [open, loadSharedUsers]);
+  }, [open, listId, loadSharedUsers, loadInviteLinkStatus]);
+
+  const handleGenerateLink = async () => {
+    try {
+      setError('');
+      const data = await generateInviteLink(listId);
+      setInviteLink(data.link);
+      setInviteLinkEnabled(true);
+      setSuccess('Invite link generated');
+    } catch (error) {
+      setError('Failed to generate invite link');
+    }
+  };
+
+  const handleDisableLink = async () => {
+    try {
+      setError('');
+      await disableInviteLink(listId);
+      setInviteLinkEnabled(false);
+      setSuccess('Invite link disabled');
+    } catch (error) {
+      setError('Failed to disable invite link');
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!inviteLink) return;
+
+    const writeViaFallback = () => {
+      const input = inviteLinkInputRef.current;
+      if (!input) return false;
+      try {
+        input.focus();
+        input.select();
+        input.setSelectionRange(0, inviteLink.length);
+        return document.execCommand('copy');
+      } catch {
+        return false;
+      }
+    };
+
+    let ok = false;
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(inviteLink);
+        ok = true;
+      } else {
+        ok = writeViaFallback();
+      }
+    } catch {
+      ok = writeViaFallback();
+    }
+
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } else {
+      setError('Could not copy link. Select and copy it manually.');
+    }
+  };
+
+  const handleToggleAnonymous = async (e) => {
+    try {
+      setError('');
+      const allow = e.target.checked;
+      await setAnonymousClaims(listId, allow);
+      setAllowAnonymous(allow);
+    } catch (error) {
+      setError('Failed to update anonymous claims setting');
+    }
+  };
 
   const handleUnshare = async (userId) => {
     try {
@@ -137,6 +245,94 @@ function ShareListDialog({ open, onClose, listId }) {
             {success}
           </Alert>
         )}
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1.5, color: colors.text.secondary }}>
+            Share via Link
+          </Typography>
+
+          {inviteLinkEnabled && inviteLink ? (
+            <>
+              <TextField
+                fullWidth
+                value={inviteLink}
+                size="small"
+                inputRef={inviteLinkInputRef}
+                onFocus={(e) => e.target.select()}
+                InputProps={{
+                  readOnly: true,
+                  endAdornment: (
+                    <Tooltip title={copied ? 'Copied!' : 'Copy link'}>
+                      <IconButton
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={handleCopyLink}
+                        edge="end"
+                        size="small"
+                      >
+                        <CopyIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  ),
+                }}
+                sx={{ mb: 1 }}
+              />
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button
+                  size="small"
+                  startIcon={<RefreshIcon />}
+                  onClick={handleGenerateLink}
+                  sx={{ color: colors.text.secondary }}
+                >
+                  Regenerate
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<LinkOffIcon />}
+                  onClick={handleDisableLink}
+                  sx={{ color: colors.error }}
+                >
+                  Disable Link
+                </Button>
+              </Box>
+            </>
+          ) : (
+            <Button
+              variant="outlined"
+              startIcon={<LinkIcon />}
+              onClick={handleGenerateLink}
+              fullWidth
+              sx={{ py: 1.25 }}
+            >
+              Generate Invite Link
+            </Button>
+          )}
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={allowAnonymous}
+                onChange={handleToggleAnonymous}
+                size="small"
+                disabled={!inviteLinkEnabled}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body2">Allow claims without sign-in</Typography>
+                <Typography variant="caption" sx={{ color: colors.text.muted }}>
+                  Let people claim items without creating an account
+                </Typography>
+              </Box>
+            }
+            sx={{ mt: 1.5, ml: 0 }}
+          />
+        </Box>
+
+        <Divider sx={{ mb: 3 }} />
+
+        <Typography variant="subtitle2" sx={{ mb: 1.5, color: colors.text.secondary }}>
+          Invite by Email
+        </Typography>
 
         <form onSubmit={handleShare}>
           <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start' }}>

--- a/frontend/src/components/WishlistItem.js
+++ b/frontend/src/components/WishlistItem.js
@@ -25,9 +25,9 @@ import { colors } from '../theme';
 
 function WishlistItem({ item, onEdit, onDelete, isSharedList, onClaim }) {
   const { user } = useAuth();
-  const isClaimedByMe = item.status?.claimedBy?._id === user?._id;
-  const isClaimedByOther = item.status?.claimedBy && !isClaimedByMe;
   const claimer = item.status?.claimedBy;
+  const isClaimedByMe = !!(claimer && user && claimer._id === user._id);
+  const isClaimedByOther = !!(claimer && !isClaimedByMe);
   const isClaimed = isClaimedByMe || isClaimedByOther;
   // Only show claimed styling on shared lists - owners should never see items as claimed
   const showClaimedStyle = isClaimed && isSharedList;

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -35,9 +35,20 @@ export const AuthProvider = ({ children }) => {
     checkAuth();
   }, [checkAuth]);
 
-  const login = () => {
+  const login = (redirectUrl = null) => {
+    if (redirectUrl) {
+      sessionStorage.setItem('postLoginRedirect', redirectUrl);
+    }
     const baseUrl = window.location.origin;
     window.location.href = `${baseUrl}/api/auth/google`;
+  };
+
+  const getPostLoginRedirect = () => {
+    const redirect = sessionStorage.getItem('postLoginRedirect');
+    if (redirect) {
+      sessionStorage.removeItem('postLoginRedirect');
+    }
+    return redirect;
   };
 
   const logout = async () => {
@@ -50,12 +61,13 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ 
-      user, 
-      loading, 
-      login, 
+    <AuthContext.Provider value={{
+      user,
+      loading,
+      login,
       logout,
-      refreshAuth: checkAuth  // Expose the refresh function
+      refreshAuth: checkAuth,
+      getPostLoginRedirect
     }}>
       {children}
     </AuthContext.Provider>

--- a/frontend/src/pages/InvitePage.js
+++ b/frontend/src/pages/InvitePage.js
@@ -1,0 +1,552 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Avatar,
+  Alert,
+  Switch,
+  FormControlLabel,
+  Collapse,
+  Divider,
+  alpha,
+} from '@mui/material';
+import Masonry from '@mui/lab/Masonry';
+import {
+  Google as GoogleIcon,
+  CalendarMonth as CalendarIcon,
+  Login as JoinIcon,
+  Visibility as ViewOnlyIcon,
+  Warning as WarningIcon,
+} from '@mui/icons-material';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import WishlistItem from '../components/WishlistItem';
+import { getPublicList, joinListViaInvite, claimItemPublic } from '../services/api';
+import { colors } from '../theme';
+
+function InvitePage() {
+  const { token } = useParams();
+  const navigate = useNavigate();
+  const { user, loading: authLoading, login } = useAuth();
+
+  const [listData, setListData] = useState(null);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [joining, setJoining] = useState(false);
+
+  // Welcome modal: 'choice' shows sign-in/guest options, 'guestWarning' shows the warning
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
+  const [welcomeStep, setWelcomeStep] = useState('choice');
+
+  const [showClaimedItems, setShowClaimedItems] = useState(() => {
+    return localStorage.getItem('showClaimedItems') === 'true';
+  });
+
+  const handleToggleClaimedItems = (checked) => {
+    setShowClaimedItems(checked);
+    localStorage.setItem('showClaimedItems', checked.toString());
+  };
+
+  // Anonymous claim modal
+  const [claimModalOpen, setClaimModalOpen] = useState(false);
+  const [claimingItemId, setClaimingItemId] = useState(null);
+  const [claimerName, setClaimerName] = useState('');
+  const [claimError, setClaimError] = useState('');
+
+  const loadList = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getPublicList(token);
+      setListData(data);
+      setItems(data.items);
+
+      if (data.viewer?.isAuthenticated && data.viewer?.isSharedWith) {
+        navigate(`/list/${data.list._id}`, { replace: true });
+        return;
+      }
+
+      // Show welcome modal once per session for guests
+      if (!data.viewer?.isAuthenticated && !sessionStorage.getItem(`invite-welcome-${token}`)) {
+        setWelcomeOpen(true);
+        sessionStorage.setItem(`invite-welcome-${token}`, '1');
+      }
+    } catch (err) {
+      if (err.response?.status === 404) {
+        setError('This invite link is no longer active.');
+      } else {
+        setError('Something went wrong. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [token, navigate]);
+
+  useEffect(() => {
+    if (!authLoading) {
+      loadList();
+    }
+  }, [authLoading, loadList]);
+
+  const list = listData?.list;
+  const allowAnonymousClaims = !!list?.allowAnonymousClaims;
+  const isAuthed = !!user;
+  const canClaim = isAuthed || allowAnonymousClaims;
+  const unclaimedItems = items.filter(i => !i.status?.claimedBy);
+  const claimedItems = items.filter(i => i.status?.claimedBy);
+
+  const handleSignIn = () => {
+    login(`/invite/${token}`);
+  };
+
+  const handleJoin = async () => {
+    if (!isAuthed) {
+      handleSignIn();
+      return;
+    }
+    try {
+      setJoining(true);
+      const result = await joinListViaInvite(token);
+      navigate(`/list/${result.listId}`, { replace: true });
+    } catch (err) {
+      setError(err.response?.data?.message || 'Failed to join list');
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const handleClaimItem = async (item) => {
+    if (isAuthed) {
+      try {
+        const updated = await claimItemPublic(token, item._id);
+        setItems(prev => prev.map(i => (i._id === item._id ? { ...i, status: updated.status } : i)));
+      } catch (err) {
+        setError(err.response?.data?.message || 'Failed to claim item');
+      }
+      return;
+    }
+
+    if (!allowAnonymousClaims) return;
+    setClaimingItemId(item._id);
+    setClaimerName('');
+    setClaimError('');
+    setClaimModalOpen(true);
+  };
+
+  const submitAnonymousClaim = async () => {
+    if (!claimerName.trim()) {
+      setClaimError('Please enter your name');
+      return;
+    }
+    try {
+      const updated = await claimItemPublic(token, claimingItemId, { claimerName: claimerName.trim() });
+      setItems(prev =>
+        prev.map(i => (i._id === claimingItemId ? { ...i, status: updated.status } : i))
+      );
+      setClaimModalOpen(false);
+    } catch (err) {
+      setClaimError(err.response?.data?.message || 'Failed to claim item');
+    }
+  };
+
+  if (loading || authLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+        <CircularProgress sx={{ color: colors.primary }} />
+      </Box>
+    );
+  }
+
+  if (error && !list) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h5" sx={{ mb: 2, color: colors.text.primary }}>
+          Link Not Found
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          {error}
+        </Typography>
+        <Button variant="contained" onClick={() => navigate('/login')}>
+          Go to Gift Guru
+        </Button>
+      </Box>
+    );
+  }
+
+  if (!list) return null;
+
+  return (
+    <Box>
+      {/* Hero Section — mirrors WishlistPage */}
+      <Box
+        sx={{
+          position: 'relative',
+          mb: 4,
+          p: { xs: 3, sm: 4 },
+          borderRadius: '20px',
+          background: `linear-gradient(135deg, ${alpha(colors.primary, 0.1)} 0%, ${alpha(colors.secondary, 0.05)} 100%)`,
+          border: `1px solid ${colors.border}`,
+          overflow: 'hidden',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: '40%',
+            height: '100%',
+            background: `radial-gradient(circle at 100% 0%, ${alpha(colors.primary, 0.15)} 0%, transparent 70%)`,
+            pointerEvents: 'none',
+          },
+        }}
+      >
+        <Typography
+          variant="h3"
+          sx={{
+            fontWeight: 700,
+            fontSize: { xs: '1.75rem', sm: '2.25rem' },
+            pb: 0.5,
+            mb: 2,
+            background: `linear-gradient(135deg, ${colors.text.primary} 0%, ${colors.primary} 100%)`,
+            backgroundClip: 'text',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+          }}
+        >
+          {list.name}
+        </Typography>
+
+        {list.owner && (
+          <Box display="flex" alignItems="center">
+            <Avatar
+              src={list.owner.picture}
+              alt={list.owner.name}
+              sx={{ width: 44, height: 44, mr: 1.5, border: `2px solid ${colors.primary}` }}
+            >
+              {list.owner.name?.[0] || '?'}
+            </Avatar>
+            <Box>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                {list.owner.name || 'Unknown User'}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                List Owner
+              </Typography>
+            </Box>
+          </Box>
+        )}
+
+        {list.description && (
+          <Typography
+            variant="body1"
+            sx={{
+              color: colors.text.secondary,
+              mt: 2.5,
+              pl: 2,
+              borderLeft: `3px solid ${colors.primary}`,
+              fontStyle: 'italic',
+            }}
+          >
+            {list.description}
+          </Typography>
+        )}
+
+        {list.event_date && (
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 1,
+              mt: 3,
+              px: 2,
+              py: 1,
+              borderRadius: '10px',
+              backgroundColor: alpha(colors.primary, 0.1),
+              border: `1px solid ${alpha(colors.primary, 0.2)}`,
+            }}
+          >
+            <CalendarIcon sx={{ color: colors.primary, fontSize: 20 }} />
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {new Date(list.event_date.split('T')[0] + 'T12:00:00').toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      {/* Action / Status Bar */}
+      <Box sx={{ mb: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5, alignItems: 'center' }}>
+        {isAuthed ? (
+          <Button
+            variant="contained"
+            startIcon={<JoinIcon />}
+            onClick={handleJoin}
+            disabled={joining}
+          >
+            {joining ? 'Joining...' : 'Join This List'}
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="contained"
+              startIcon={<GoogleIcon />}
+              onClick={handleSignIn}
+              sx={{
+                background: '#fff',
+                color: '#1f1f1f',
+                '&:hover': { background: '#f5f5f5' },
+              }}
+            >
+              Sign in with Google
+            </Button>
+            {!allowAnonymousClaims && (
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  px: 1.5,
+                  py: 0.75,
+                  borderRadius: '10px',
+                  backgroundColor: alpha(colors.text.muted, 0.1),
+                  border: `1px solid ${alpha(colors.text.muted, 0.2)}`,
+                }}
+              >
+                <ViewOnlyIcon sx={{ fontSize: 18, color: colors.text.secondary }} />
+                <Typography variant="caption" sx={{ color: colors.text.secondary }}>
+                  Read-only — sign in to claim
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Items Grid — same Masonry + claimed-collapse as WishlistPage */}
+      {items.length > 0 ? (
+        <>
+          {unclaimedItems.length > 0 && (
+            <Masonry
+              columns={{ xs: 1, sm: 2, md: 3, lg: 4 }}
+              spacing={2}
+              defaultHeight={450}
+              defaultColumns={4}
+              defaultSpacing={2}
+            >
+              {unclaimedItems.map((item) => (
+                <WishlistItem
+                  key={item._id}
+                  item={item}
+                  isSharedList={true}
+                  onClaim={canClaim ? handleClaimItem : undefined}
+                />
+              ))}
+            </Masonry>
+          )}
+
+          {claimedItems.length > 0 && (
+            <Box sx={{ my: 4, textAlign: 'center' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5 }}>
+                <Divider sx={{ flex: 1 }} />
+                <Typography variant="body2" color="text.secondary">
+                  🎁 {claimedItems.length} claimed {claimedItems.length === 1 ? 'item' : 'items'}
+                </Typography>
+                <Divider sx={{ flex: 1 }} />
+              </Box>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+                Keep the surprise satisfying! Peek only if you need to coordinate gifts.
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={showClaimedItems}
+                    onChange={(e) => handleToggleClaimedItems(e.target.checked)}
+                    size="small"
+                  />
+                }
+                label={showClaimedItems ? 'Hide claimed' : 'Show claimed'}
+              />
+            </Box>
+          )}
+
+          <Collapse in={showClaimedItems && claimedItems.length > 0}>
+            <Masonry
+              columns={{ xs: 1, sm: 2, md: 3, lg: 4 }}
+              spacing={2}
+              defaultHeight={450}
+              defaultColumns={4}
+              defaultSpacing={2}
+            >
+              {claimedItems.map((item) => (
+                <WishlistItem
+                  key={item._id}
+                  item={item}
+                  isSharedList={true}
+                  onClaim={canClaim ? handleClaimItem : undefined}
+                />
+              ))}
+            </Masonry>
+          </Collapse>
+
+          {unclaimedItems.length === 0 && claimedItems.length > 0 && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                py: 6,
+                px: 4,
+                borderRadius: '20px',
+                backgroundColor: alpha(colors.background.elevated, 0.3),
+                border: `1px dashed ${colors.border}`,
+                mb: 2,
+              }}
+            >
+              <Typography variant="h6" color="text.secondary" sx={{ mb: 1, fontWeight: 500 }}>
+                All items have been claimed!
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Toggle "Show claimed" above to see what's being gifted.
+              </Typography>
+            </Box>
+          )}
+        </>
+      ) : (
+        <Box sx={{ textAlign: 'center', py: 6 }}>
+          <Typography variant="body1" color="text.secondary">
+            This wishlist has no items yet.
+          </Typography>
+        </Box>
+      )}
+
+      {/* Welcome Modal */}
+      <Dialog
+        open={welcomeOpen}
+        onClose={() => setWelcomeOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: '20px' } }}
+      >
+        {welcomeStep === 'choice' ? (
+          <>
+            <DialogTitle sx={{ pb: 1 }}>You've been invited!</DialogTitle>
+            <DialogContent>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Sign in to join this list, claim items, and coordinate with other gift-givers.
+              </Typography>
+            </DialogContent>
+            <DialogActions sx={{ px: 3, pb: 3, flexDirection: 'column', alignItems: 'stretch', gap: 1 }}>
+              <Button
+                variant="contained"
+                fullWidth
+                startIcon={<GoogleIcon />}
+                onClick={handleSignIn}
+                sx={{ background: '#fff', color: '#1f1f1f', '&:hover': { background: '#f5f5f5' } }}
+              >
+                Sign in with Google
+              </Button>
+              <Button
+                variant="text"
+                fullWidth
+                onClick={() => setWelcomeStep('guestWarning')}
+                sx={{ color: colors.text.secondary }}
+              >
+                Continue as a guest
+              </Button>
+            </DialogActions>
+          </>
+        ) : (
+          <>
+            <DialogTitle sx={{ pb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+              <WarningIcon sx={{ color: colors.warning }} />
+              Heads up
+            </DialogTitle>
+            <DialogContent>
+              {allowAnonymousClaims ? (
+                <Typography variant="body2" color="text.secondary">
+                  You can claim items as a guest, but <strong>guest claims cannot be undone</strong>.
+                  Make sure you really want an item before claiming.
+                </Typography>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Guest claiming is not enabled on this list, so you'll be in <strong>read-only</strong> mode.
+                  Sign in if you'd like to claim an item.
+                </Typography>
+              )}
+            </DialogContent>
+            <DialogActions sx={{ px: 3, pb: 3 }}>
+              <Button onClick={() => setWelcomeStep('choice')} sx={{ color: colors.text.secondary }}>
+                Back
+              </Button>
+              <Button variant="contained" onClick={() => setWelcomeOpen(false)}>
+                Got it
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+
+      {/* Anonymous Claim Modal */}
+      <Dialog
+        open={claimModalOpen}
+        onClose={() => setClaimModalOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: '20px' } }}
+      >
+        <DialogTitle>Claim This Item</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Guest claims can't be undone. Make sure you are confident you are buying this item.
+          </Alert>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Enter your name so others know who claimed it.
+          </Typography>
+          <TextField
+            autoFocus
+            fullWidth
+            label="Your Name"
+            value={claimerName}
+            onChange={(e) => setClaimerName(e.target.value)}
+            placeholder="e.g. John"
+            error={!!claimError}
+            helperText={claimError}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                submitAnonymousClaim();
+              }
+            }}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3 }}>
+          <Button onClick={() => setClaimModalOpen(false)} sx={{ color: colors.text.secondary }}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={submitAnonymousClaim}>
+            Claim
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+export default InvitePage;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -76,3 +76,43 @@ export const claimItem = async (listId, itemId) => {
   const response = await api.post(`/api/share/claim/${listId}/${itemId}`, {});
   return response.data;
 };
+
+// Public invite link endpoints
+export const getPublicList = async (token) => {
+  const response = await api.get(`/api/public/invite/${token}`);
+  return response.data;
+};
+
+export const joinListViaInvite = async (token) => {
+  const response = await api.post(`/api/public/invite/${token}/join`);
+  return response.data;
+};
+
+export const claimItemPublic = async (token, itemId, claimerInfo = null) => {
+  const response = await api.post(
+    `/api/public/invite/${token}/claim/${itemId}`,
+    claimerInfo
+  );
+  return response.data;
+};
+
+// Invite link management (owner-only)
+export const getInviteLinkStatus = async (listId) => {
+  const response = await api.get(`/api/share/${listId}/invite-link`);
+  return response.data;
+};
+
+export const generateInviteLink = async (listId) => {
+  const response = await api.post(`/api/share/${listId}/invite-link`);
+  return response.data;
+};
+
+export const disableInviteLink = async (listId) => {
+  const response = await api.delete(`/api/share/${listId}/invite-link`);
+  return response.data;
+};
+
+export const setAnonymousClaims = async (listId, allow) => {
+  const response = await api.put(`/api/share/${listId}/anonymous-claims`, { allow });
+  return response.data;
+};

--- a/mongo/seeds/wishlist.wishlists.json
+++ b/mongo/seeds/wishlist.wishlists.json
@@ -1,7 +1,7 @@
 [{
   "name": "Birthday List",
   "description": "For friends",
-  "event_date": {"$date": "2025-03-15T00:00:00.000Z"},
+  "event_date": {"$date": "2027-03-15T00:00:00.000Z"},
   "user": {"$oid": "6763b6892d9d2bba36992ecd"},
   "createdAt": {"$date": "2024-12-19T06:00:41.698Z"},
   "sharedWith": [
@@ -62,7 +62,7 @@
 {
   "name": "Birthday list",
   "description": "Please buy me a gift!",
-  "event_date": {"$date": "2025-06-22T00:00:00.000Z"},
+  "event_date": {"$date": "2026-06-22T00:00:00.000Z"},
   "user": {"$oid": "6763b7222d9d2bba36992edc"},
   "createdAt": {"$date": "2024-12-19T06:03:14.096Z"},
   "sharedWith": [
@@ -109,7 +109,7 @@
 {
   "name": "My Wishlist",
   "description": "Default wishlist",
-  "event_date": {"$date": "2025-08-10T00:00:00.000Z"},
+  "event_date": {"$date": "2026-08-10T00:00:00.000Z"},
   "user": {"$oid": "676a0ed1f6c759cb6987c866"},
   "createdAt": {"$date": "2024-12-24T01:30:57.092Z"},
   "sharedWith": [
@@ -148,7 +148,7 @@
 {
   "name": "Christmas List",
   "description": "Help me out, I'm broke!",
-  "event_date": {"$date": "2025-12-25T00:00:00.000Z"},
+  "event_date": {"$date": "2026-12-25T00:00:00.000Z"},
   "user": {"$oid": "6763b6892d9d2bba36992ecd"},
   "createdAt": {"$date": "2024-12-27T05:50:30.526Z"},
   "sharedWith": [


### PR DESCRIPTION
## Summary
- Owners can generate / regenerate / disable a per-list invite link from the share dialog, and optionally allow guest (anonymous) claims.
- New unauthenticated route `/invite/:token` reuses the authed shared view's hero, Masonry, and `WishlistItem` so guest and signed-in views look identical. A one-time welcome modal asks visitors to sign in or continue as a guest, with a warning that branches on whether guest claims are enabled.
- Authed visitors auto-join when they open the link or claim an item; already-joined users redirect to the normal list page.
- Seed `event_date`s bumped so the demo lists don't render as archived.

## Test plan
- [ ] `cd backend && npm test -- __tests__/integration/invite-links.test.js` passes (20 tests covering token lifecycle, public access, join, anonymous claims, authed claims, and toggle authorization)
- [ ] As an owner: generate a link, copy it, regenerate, disable; toggle "Allow claims without sign-in"
- [ ] As a guest in an incognito window: open the link, see the welcome modal, "Continue as a guest" warning differs based on the anonymous-claims toggle
- [ ] As a guest with anonymous claims enabled: claim an item, confirm the typed name shows on the card
- [ ] As an authed non-member: open the link, click "Join This List", land on `/list/:id`
- [ ] As an authed non-member: click claim on an item, verify auto-join + claim recorded