### PR TITLE
Add GitHub Actions for tests + OIDC-based deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,149 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which component to deploy
+        required: true
+        default: both
+        type: choice
+        options: [both, backend, frontend]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ACCOUNT_ID: "471112920823"
+  ECR_REPOSITORY: wishlist-backend
+  ECS_CLUSTER: wishlist-cluster-prod
+  ECS_SERVICE: wishlist-backend-prod
+  S3_BUCKET: ${{ vars.FRONTEND_S3_BUCKET }}
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+  AWS_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+
+  backend:
+    name: Backend (ECR + ECS)
+    needs: changes
+    if: |
+      (github.event_name == 'push' && needs.changes.outputs.backend == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'backend'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+            ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Force ECS deployment
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --force-new-deployment \
+            --region "$AWS_REGION" > /dev/null
+
+      - name: Wait for service to stabilize
+        run: |
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --region "$AWS_REGION"
+
+  frontend:
+    name: Frontend (S3 + CloudFront)
+    needs: changes
+    if: |
+      (github.event_name == 'push' && needs.changes.outputs.frontend == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'frontend'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build
+        run: |
+          cd frontend
+          npm ci
+          CI=true npm run build
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync static assets to S3
+        run: |
+          aws s3 sync frontend/build/ "s3://$S3_BUCKET/" \
+            --region "$AWS_REGION" \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "index.html" \
+            --exclude "manifest.json"
+
+      - name: Upload index.html and manifest.json with short cache
+        run: |
+          aws s3 cp frontend/build/index.html "s3://$S3_BUCKET/index.html" \
+            --region "$AWS_REGION" \
+            --cache-control "public,max-age=300,must-revalidate" \
+            --content-type "text/html"
+          if [ -f frontend/build/manifest.json ]; then
+            aws s3 cp frontend/build/manifest.json "s3://$S3_BUCKET/manifest.json" \
+              --region "$AWS_REGION" \
+              --cache-control "public,max-age=300,must-revalidate" \
+              --content-type "application/json"
+          fi
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - run: npm ci
+      - run: npm test
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: CI=true npm run build

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -1,0 +1,110 @@
+# GitHub Actions OIDC provider + deploy role.
+# Lets workflows on the main branch assume an IAM role via short-lived
+# tokens instead of long-lived AWS access keys.
+
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "github_actions_deploy" {
+  name = "${var.app_name}-github-actions-deploy-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "github_actions_deploy" {
+  name = "${var.app_name}-github-actions-deploy-${var.environment}"
+  role = aws_iam_role.github_actions_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrAuth"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "EcrPushPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+        Resource = aws_ecr_repository.backend.arn
+      },
+      {
+        Sid    = "EcsDeploy"
+        Effect = "Allow"
+        Action = [
+          "ecs:UpdateService",
+          "ecs:DescribeServices"
+        ]
+        Resource = aws_ecs_service.backend.id
+      },
+      {
+        Sid    = "EcsPassRole"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          aws_iam_role.ecs_task_execution_role.arn,
+          aws_iam_role.ecs_task_role.arn
+        ]
+      },
+      {
+        Sid    = "S3FrontendSync"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:PutObjectAcl"
+        ]
+        Resource = [
+          aws_s3_bucket.frontend.arn,
+          "${aws_s3_bucket.frontend.arn}/*"
+        ]
+      },
+      {
+        Sid      = "CloudFrontInvalidate"
+        Effect   = "Allow"
+        Action   = "cloudfront:CreateInvalidation"
+        Resource = aws_cloudfront_distribution.main.arn
+      }
+    ]
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -21,4 +21,10 @@ output "cloudfront_domain_name" {
 output "s3_bucket_name" {
   description = "The name of the S3 bucket for frontend"
   value       = aws_s3_bucket.frontend.bucket
-} 
+}
+
+output "github_actions_deploy_role_arn" {
+  description = "ARN of the IAM role assumed by GitHub Actions deploy workflow"
+  value       = aws_iam_role.github_actions_deploy.arn
+}
+

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
   }
 
   backend "s3" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,4 +50,11 @@ variable "cloudfront_secret" {
   type        = string
   sensitive   = true
   default     = "change-me-in-production"
-} 
+}
+
+variable "github_repo" {
+  description = "GitHub repo (owner/name) allowed to assume the deploy role via OIDC"
+  type        = string
+  default     = "hscopalm/shareable-wishlists"
+}
+


### PR DESCRIPTION
## Summary
Moves testing and deploys off the laptop and into GitHub Actions. Public repo, so Actions minutes are free.

- **`.github/workflows/test.yml`** runs on every PR and push to main: backend Jest (uses the existing `mongodb-memory-server`, no service container needed) and a frontend production build.
- **`.github/workflows/deploy.yml`** runs on push to main with path filters, so only the changed component deploys. Backend job builds + pushes to ECR and forces an ECS deployment; frontend job builds React, syncs to S3 with the same cache headers `deploy.sh` uses, and invalidates CloudFront. `workflow_dispatch` provides a manual escape hatch with a backend/frontend/both selector.
- Auth uses GitHub's **OIDC provider** — no long-lived AWS keys in repo secrets. `terraform/github_oidc.tf` provisions the trust + a least-privilege deploy role (ECR push on the backend repo, ECS update on the backend service, IAM PassRole for the task roles, S3 read/write on the frontend bucket, CloudFront invalidation on the distribution). The `sub` is scoped to `refs/heads/main` so only the main branch can assume it.

## Rollout steps after merge
1. `cd terraform && terraform init && terraform apply` to create the OIDC provider and deploy role.
2. Capture outputs: `terraform output github_actions_deploy_role_arn`, `terraform output s3_bucket_name`, `terraform output cloudfront_distribution_id`.
3. In the repo settings → Variables → Actions, add: `AWS_DEPLOY_ROLE_ARN`, `FRONTEND_S3_BUCKET`, `CLOUDFRONT_DISTRIBUTION_ID`.
4. Trigger the workflow manually via the Actions UI (`Run workflow` → `both`) to verify the first deploy end-to-end. `deploy.sh` stays in the repo as a manual fallback.

## Test plan
- [ ] After merge, PR CI runs both backend tests and frontend build to green
- [ ] `terraform apply` succeeds and outputs the role ARN
- [ ] Manual `workflow_dispatch` deploy ships both components and the live site reflects the change
- [ ] Subsequent push to main with only `frontend/**` changes runs only the frontend job (path filter check)