### PR TITLE
Fix duplicate aws_caller_identity in github_oidc.tf

### DIFF
--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -12,8 +12,6 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
 }
 
-data "aws_caller_identity" "current" {}
-
 resource "aws_iam_role" "github_actions_deploy" {
   name = "${var.app_name}-github-actions-deploy-${var.environment}"
 


### PR DESCRIPTION
## Summary
`terraform/github_oidc.tf` re-declared `data "aws_caller_identity" "current"`, which is already in `terraform/data.tf`. Terraform rejects duplicate data resource names per type, so `terraform apply` failed before the OIDC provider could be created. The block was unused in `github_oidc.tf` anyway — just dropping it.

## Test plan
- [ ] `cd terraform && terraform apply` succeeds and creates the OIDC provider + deploy role