### PR TITLE
feat: dev mode user picker on login page

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -29,11 +29,18 @@ router.get('/debug', (req, res) => {
   });
 });
 
-// Development mode: Auto-login route
+// Development mode: Auto-login + user picker routes
 if (process.env.NODE_ENV === 'development' && process.env.DEV_AUTO_LOGIN === 'true') {
+  const findDevUser = async (userId) => {
+    if (userId) {
+      return User.findById(userId);
+    }
+    return User.findOne({ email: process.env.DEV_USER_EMAIL || 'hscopalm@gmail.com' });
+  };
+
   router.get('/dev-login', async (req, res) => {
     try {
-      const devUser = await User.findOne({ email: process.env.DEV_USER_EMAIL || 'hscopalm@gmail.com' });
+      const devUser = await findDevUser(req.query.userId);
       if (!devUser) {
         return res.status(404).json({ message: 'Dev user not found. Run seed script first.' });
       }
@@ -48,13 +55,21 @@ if (process.env.NODE_ENV === 'development' && process.env.DEV_AUTO_LOGIN === 'tr
       res.status(500).json({ message: 'Error finding dev user', error: error.message });
     }
   });
-}
 
-// In dev mode with auto-login, redirect /google to dev-login flow
-if (process.env.NODE_ENV === 'development' && process.env.DEV_AUTO_LOGIN === 'true') {
+  router.get('/dev-users', async (req, res) => {
+    try {
+      const users = await User.find({ isPending: { $ne: true } })
+        .select('_id email name picture')
+        .sort({ name: 1 });
+      res.json(users);
+    } catch (error) {
+      res.status(500).json({ message: 'Error listing dev users', error: error.message });
+    }
+  });
+
   router.get('/google', async (req, res) => {
     try {
-      const devUser = await User.findOne({ email: process.env.DEV_USER_EMAIL || 'hscopalm@gmail.com' });
+      const devUser = await findDevUser(req.query.userId);
       if (!devUser) {
         return res.redirect(`${process.env.FRONTEND_URL}/?error=dev_user_not_found`);
       }

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -35,12 +35,13 @@ export const AuthProvider = ({ children }) => {
     checkAuth();
   }, [checkAuth]);
 
-  const login = (redirectUrl = null) => {
+  const login = (redirectUrl = null, userId = null) => {
     if (redirectUrl) {
       sessionStorage.setItem('postLoginRedirect', redirectUrl);
     }
     const baseUrl = window.location.origin;
-    window.location.href = `${baseUrl}/api/auth/google`;
+    const query = userId ? `?userId=${encodeURIComponent(userId)}` : '';
+    window.location.href = `${baseUrl}/api/auth/google${query}`;
   };
 
   const getPostLoginRedirect = () => {

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,12 +1,26 @@
-import React from 'react';
-import { Box, Button, Typography, alpha, Link } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Typography, alpha, Link, Avatar, Stack, Divider } from '@mui/material';
 import { Google as GoogleIcon } from '@mui/icons-material';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { api } from '../services/api';
 import { colors } from '../theme';
 
 function LoginPage() {
   const { login } = useAuth();
+  const [devUsers, setDevUsers] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get('/api/auth/dev-users')
+      .then((res) => {
+        if (!cancelled) setDevUsers(res.data);
+      })
+      .catch(() => {
+        if (!cancelled) setDevUsers([]);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   return (
     <Box
@@ -106,7 +120,7 @@ function LoginPage() {
           fullWidth
           variant="contained"
           startIcon={<GoogleIcon />}
-          onClick={login}
+          onClick={() => login()}
           sx={{
             py: 1.5,
             fontSize: '1rem',
@@ -125,6 +139,49 @@ function LoginPage() {
         >
           Continue with Google
         </Button>
+
+        {/* Dev mode: pick which seed user to log in as */}
+        {devUsers && devUsers.length > 0 && (
+          <Box sx={{ width: '100%', mt: 3 }}>
+            <Divider sx={{ mb: 2, '&::before, &::after': { borderColor: colors.border } }}>
+              <Typography variant="caption" color="text.secondary">
+                Dev mode — log in as
+              </Typography>
+            </Divider>
+            <Stack spacing={1}>
+              {devUsers.map((u) => (
+                <Button
+                  key={u._id}
+                  fullWidth
+                  onClick={() => login(null, u._id)}
+                  sx={{
+                    justifyContent: 'flex-start',
+                    py: 1,
+                    px: 1.5,
+                    borderRadius: '12px',
+                    textTransform: 'none',
+                    color: colors.text.primary,
+                    border: `1px solid ${colors.border}`,
+                    '&:hover': {
+                      background: alpha(colors.primary, 0.08),
+                      borderColor: alpha(colors.primary, 0.4),
+                    },
+                  }}
+                >
+                  <Avatar src={u.picture} alt={u.name} sx={{ width: 28, height: 28, mr: 1.5 }} />
+                  <Box sx={{ textAlign: 'left', overflow: 'hidden' }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2 }} noWrap>
+                      {u.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" noWrap component="div">
+                      {u.email}
+                    </Typography>
+                  </Box>
+                </Button>
+              ))}
+            </Stack>
+          </Box>
+        )}
 
         {/* Footer */}
         <Typography


### PR DESCRIPTION
Closes #11

## Summary
- Adds `GET /api/auth/dev-users` (dev + `DEV_AUTO_LOGIN=true` only) returning seeded users.
- `/api/auth/google` and `/api/auth/dev-login` accept `?userId=` to choose which user to log in as. Default `DEV_USER_EMAIL` fallback preserved.
- `LoginPage` fetches the list on mount and renders a picker below the Google button. In production the route 401s and the picker stays hidden.
- Cold-start auto-login behavior is unchanged; switch users by logging out and picking from the login page.

## Test plan
- [ ] `docker-compose up --build -d` from this worktree, `cd backend && npm run seed`
- [ ] Visit http://localhost, log out, confirm Alice / Bob / Carol appear under "Dev mode — log in as"
- [ ] Click Bob, verify session lands on Bob's lists
- [ ] Confirm `curl http://localhost:5000/api/auth/dev-users` returns the seed user list
- [ ] Production safety: route is gated by `NODE_ENV=development && DEV_AUTO_LOGIN=true`, so it does not register outside dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)