### PR TITLE
feat: add optional mailing address to wishlists

### DIFF
--- a/backend/__tests__/integration/lists.test.js
+++ b/backend/__tests__/integration/lists.test.js
@@ -95,6 +95,32 @@ describe('Lists Routes', () => {
       expect(new Date(res.body.event_date).toDateString()).toBe(eventDate.toDateString());
     });
 
+    it('should persist a mailing address when provided', async () => {
+      const alice = await createUser({ email: 'alice@test.com', name: 'Alice' });
+      const agent = await loginAs(alice);
+
+      const mailingAddress = {
+        recipientName: 'Alice Doe',
+        line1: '123 Main St',
+        line2: 'Apt 4',
+        city: 'Portland',
+        state: 'OR',
+        postalCode: '97201',
+        country: 'USA',
+      };
+
+      const res = await agent
+        .post('/api/lists')
+        .send({ name: 'Registry', mailingAddress });
+
+      expect(res.status).toBe(201);
+      expect(res.body.mailingAddress).toMatchObject(mailingAddress);
+
+      const saved = await Wishlist.findById(res.body._id);
+      expect(saved.mailingAddress.line1).toBe('123 Main St');
+      expect(saved.mailingAddress.recipientName).toBe('Alice Doe');
+    });
+
     it('should fail without required name field', async () => {
       const alice = await createUser({ email: 'alice@test.com', name: 'Alice' });
       const agent = await loginAs(alice);
@@ -189,6 +215,51 @@ describe('Lists Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.name).toBe('Updated Name');
       expect(res.body.description).toBe('New description');
+    });
+
+    it('should update mailing address and return it on GET to shared users', async () => {
+      const { alice, bob } = await createTestUsers();
+      const wishlist = await createSharedWishlist(alice, [bob], { name: 'Registry' });
+      const ownerAgent = await loginAs(alice);
+
+      const mailingAddress = {
+        recipientName: 'Alice Doe',
+        line1: '500 Park Ave',
+        city: 'New York',
+        state: 'NY',
+        postalCode: '10022',
+        country: 'USA',
+      };
+
+      const updateRes = await ownerAgent
+        .put(`/api/lists/${wishlist._id}`)
+        .send({ name: 'Registry', mailingAddress });
+
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.mailingAddress).toMatchObject(mailingAddress);
+
+      const sharedAgent = await loginAs(bob);
+      const getRes = await sharedAgent.get(`/api/lists/${wishlist._id}`);
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.list.mailingAddress).toMatchObject(mailingAddress);
+    });
+
+    it('should clear mailing address when sent as empty object', async () => {
+      const alice = await createUser({ email: 'alice@test.com', name: 'Alice' });
+      const wishlist = await createWishlist(alice, {
+        name: 'Registry',
+        mailingAddress: { line1: '1 First St', city: 'Seattle' },
+      });
+      const agent = await loginAs(alice);
+
+      const res = await agent
+        .put(`/api/lists/${wishlist._id}`)
+        .send({ name: 'Registry', mailingAddress: {} });
+
+      expect(res.status).toBe(200);
+      const saved = await Wishlist.findById(wishlist._id);
+      expect(saved.mailingAddress.line1).toBeFalsy();
+      expect(saved.mailingAddress.city).toBeFalsy();
     });
 
     it('should not allow shared user to update list', async () => {

--- a/backend/models/Wishlist.js
+++ b/backend/models/Wishlist.js
@@ -9,6 +9,16 @@ const wishlistSchema = new mongoose.Schema({
   event_date: {
     type: Date
   },
+  mailingAddress: {
+    recipientName: String,
+    line1: String,
+    line2: String,
+    city: String,
+    state: String,
+    postalCode: String,
+    country: String,
+    _id: false
+  },
   user: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/backend/routes/lists.js
+++ b/backend/routes/lists.js
@@ -21,6 +21,7 @@ router.post('/', async (req, res) => {
       name: req.body.name,
       description: req.body.description,
       event_date: req.body.event_date,
+      mailingAddress: req.body.mailingAddress,
       user: req.user._id,
       items: []
     });
@@ -90,6 +91,7 @@ router.put('/:id', async (req, res) => {
     wishlist.name = req.body.name;
     wishlist.description = req.body.description;
     wishlist.event_date = req.body.event_date;
+    wishlist.mailingAddress = req.body.mailingAddress;
 
     const updatedWishlist = await wishlist.save();
     res.json(updatedWishlist);

--- a/backend/routes/public.js
+++ b/backend/routes/public.js
@@ -64,6 +64,7 @@ router.get('/invite/:token', async (req, res) => {
         name: wishlist.name,
         description: wishlist.description,
         event_date: wishlist.event_date,
+        mailingAddress: wishlist.mailingAddress,
         owner: {
           name: wishlist.user.name,
           picture: wishlist.user.picture

--- a/frontend/src/components/MailingAddressCard.js
+++ b/frontend/src/components/MailingAddressCard.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, Typography, alpha } from '@mui/material';
+import { LocalShipping as ShippingIcon } from '@mui/icons-material';
+import { colors } from '../theme';
+import { formatMailingAddress } from '../utils/address';
+
+function MailingAddressCard({ address }) {
+  const lines = formatMailingAddress(address);
+  if (!lines) return null;
+
+  return (
+    <Box
+      sx={{
+        mt: 2,
+        p: 2,
+        borderRadius: '12px',
+        backgroundColor: alpha(colors.primary, 0.08),
+        border: `1px solid ${alpha(colors.primary, 0.2)}`,
+        display: 'flex',
+        gap: 1.5,
+        alignItems: 'flex-start',
+      }}
+    >
+      <ShippingIcon sx={{ color: colors.primary, mt: 0.25 }} />
+      <Box>
+        <Typography variant="caption" sx={{ color: colors.primary, fontWeight: 600, letterSpacing: 0.5 }}>
+          SHIP GIFTS TO
+        </Typography>
+        {lines.map((line, i) => (
+          <Typography key={i} variant="body2" sx={{ lineHeight: 1.5 }}>
+            {line}
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export default MailingAddressCard;

--- a/frontend/src/components/MailingAddressFields.js
+++ b/frontend/src/components/MailingAddressFields.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, TextField, Typography } from '@mui/material';
+
+function MailingAddressFields({ value, onChange }) {
+  const update = (field) => (e) => onChange({ ...value, [field]: e.target.value });
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="caption" color="text.secondary">
+        Where should gift senders ship packages? Visible to anyone with access to this list.
+      </Typography>
+      <TextField
+        label="Recipient name"
+        fullWidth
+        value={value.recipientName}
+        onChange={update('recipientName')}
+      />
+      <TextField
+        label="Address line 1"
+        fullWidth
+        value={value.line1}
+        onChange={update('line1')}
+      />
+      <TextField
+        label="Address line 2"
+        fullWidth
+        value={value.line2}
+        onChange={update('line2')}
+      />
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <TextField label="City" sx={{ flex: '2 1 200px' }} value={value.city} onChange={update('city')} />
+        <TextField label="State / Region" sx={{ flex: '1 1 120px' }} value={value.state} onChange={update('state')} />
+        <TextField label="Postal code" sx={{ flex: '1 1 120px' }} value={value.postalCode} onChange={update('postalCode')} />
+      </Box>
+      <TextField label="Country" fullWidth value={value.country} onChange={update('country')} />
+    </Box>
+  );
+}
+
+export default MailingAddressFields;

--- a/frontend/src/pages/InvitePage.js
+++ b/frontend/src/pages/InvitePage.js
@@ -28,6 +28,7 @@ import {
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import WishlistItem from '../components/WishlistItem';
+import MailingAddressCard from '../components/MailingAddressCard';
 import { getPublicList, joinListViaInvite, claimItemPublic } from '../services/api';
 import { colors } from '../theme';
 
@@ -282,6 +283,8 @@ function InvitePage() {
             </Typography>
           </Box>
         )}
+
+        <MailingAddressCard address={list.mailingAddress} />
       </Box>
 
       {/* Action / Status Bar */}

--- a/frontend/src/pages/ListsPage.js
+++ b/frontend/src/pages/ListsPage.js
@@ -31,13 +31,16 @@ import { useNavigate } from 'react-router-dom';
 import { deleteList, createList, updateList } from '../services/api';
 import { formatDistanceToNow } from 'date-fns';
 import { colors } from '../theme';
+import { EMPTY_ADDRESS } from '../utils/address';
+import MailingAddressFields from '../components/MailingAddressFields';
 
 function ListsPage() {
   const { lists, refreshLists: loadLists, setCurrentList } = useList();
   const navigate = useNavigate();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingList, setEditingList] = useState(null);
-  const [formData, setFormData] = useState({ name: '', description: '', event_date: '' });
+  const [formData, setFormData] = useState({ name: '', description: '', event_date: '', mailingAddress: { ...EMPTY_ADDRESS } });
+  const [showAddressFields, setShowAddressFields] = useState(false);
   const [hoveredCard, setHoveredCard] = useState(null);
   const [showArchived, setShowArchived] = useState(false);
 
@@ -52,18 +55,22 @@ function ListsPage() {
 
   const handleCreateClick = () => {
     setEditingList(null);
-    setFormData({ name: '', description: '', event_date: '' });
+    setFormData({ name: '', description: '', event_date: '', mailingAddress: { ...EMPTY_ADDRESS } });
+    setShowAddressFields(false);
     setDialogOpen(true);
   };
 
   const handleEditClick = (event, list) => {
     event.stopPropagation();
     setEditingList(list);
+    const address = { ...EMPTY_ADDRESS, ...(list.mailingAddress || {}) };
     setFormData({
       name: list.name,
       description: list.description || '',
-      event_date: list.event_date || ''
+      event_date: list.event_date || '',
+      mailingAddress: address,
     });
+    setShowAddressFields(Object.values(list.mailingAddress || {}).some((v) => typeof v === 'string' && v.trim().length > 0));
     setDialogOpen(true);
   };
 
@@ -93,8 +100,9 @@ function ListsPage() {
       }
       await loadLists();
 
-      setFormData({ name: '', description: '', event_date: '' });
+      setFormData({ name: '', description: '', event_date: '', mailingAddress: { ...EMPTY_ADDRESS } });
       setEditingList(null);
+      setShowAddressFields(false);
       setDialogOpen(false);
     } catch (error) {
       console.error('Error saving list:', error);
@@ -562,6 +570,19 @@ function ListsPage() {
                 onChange={(e) => setFormData({ ...formData, event_date: e.target.value })}
                 InputLabelProps={{ shrink: true }}
               />
+              <Button
+                onClick={() => setShowAddressFields((v) => !v)}
+                size="small"
+                sx={{ alignSelf: 'flex-start', textTransform: 'none', color: colors.primary }}
+              >
+                {showAddressFields ? 'Hide mailing address' : 'Add a mailing address (optional)'}
+              </Button>
+              <Collapse in={showAddressFields} unmountOnExit>
+                <MailingAddressFields
+                  value={formData.mailingAddress}
+                  onChange={(mailingAddress) => setFormData({ ...formData, mailingAddress })}
+                />
+              </Collapse>
             </Box>
           </DialogContent>
           <DialogActions sx={{ px: 3, pb: 3 }}>

--- a/frontend/src/pages/WishlistPage.js
+++ b/frontend/src/pages/WishlistPage.js
@@ -34,10 +34,13 @@ import {
 import WishlistForm from '../components/WishlistForm';
 import WishlistItem from '../components/WishlistItem';
 import ShareListDialog from '../components/ShareListDialog';
+import MailingAddressFields from '../components/MailingAddressFields';
+import MailingAddressCard from '../components/MailingAddressCard';
 import { useList } from '../contexts/ListContext';
 import { deleteWishlistItem, fetchListItems, claimItem, updateList } from '../services/api';
 import { useParams, useNavigate } from 'react-router-dom';
 import { colors } from '../theme';
+import { EMPTY_ADDRESS, hasMailingAddress } from '../utils/address';
 
 function WishlistPage() {
   const { id: listId } = useParams();
@@ -50,7 +53,8 @@ function WishlistPage() {
   const [sortBy, setSortBy] = useState('createdAt');
   const [sortDirection, setSortDirection] = useState('desc');
   const [openEditDialog, setOpenEditDialog] = useState(false);
-  const [editFormData, setEditFormData] = useState({ name: '', description: '', event_date: '' });
+  const [editFormData, setEditFormData] = useState({ name: '', description: '', event_date: '', mailingAddress: { ...EMPTY_ADDRESS } });
+  const [showAddressFields, setShowAddressFields] = useState(false);
   const [showClaimedItems, setShowClaimedItems] = useState(() => {
     return localStorage.getItem('showClaimedItems') === 'true';
   });
@@ -103,11 +107,14 @@ function WishlistPage() {
 
   const openEditDialogWithHistory = useCallback(() => {
     if (currentList) {
+      const address = { ...EMPTY_ADDRESS, ...(currentList.mailingAddress || {}) };
       setEditFormData({
         name: currentList.name || '',
         description: currentList.description || '',
-        event_date: currentList.event_date || ''
+        event_date: currentList.event_date || '',
+        mailingAddress: address,
       });
+      setShowAddressFields(hasMailingAddress(currentList.mailingAddress));
       window.history.pushState({ dialog: 'edit' }, '');
       setOpenEditDialog(true);
     }
@@ -381,6 +388,8 @@ function WishlistPage() {
             </Typography>
           </Box>
         )}
+
+        <MailingAddressCard address={currentList?.mailingAddress} />
       </Box>
 
       {/* Action Bar */}
@@ -679,6 +688,19 @@ function WishlistPage() {
                 onChange={(e) => setEditFormData({ ...editFormData, event_date: e.target.value })}
                 InputLabelProps={{ shrink: true }}
               />
+              <Button
+                onClick={() => setShowAddressFields((v) => !v)}
+                size="small"
+                sx={{ alignSelf: 'flex-start', textTransform: 'none', color: colors.primary }}
+              >
+                {showAddressFields ? 'Hide mailing address' : 'Add a mailing address (optional)'}
+              </Button>
+              <Collapse in={showAddressFields} unmountOnExit>
+                <MailingAddressFields
+                  value={editFormData.mailingAddress}
+                  onChange={(mailingAddress) => setEditFormData({ ...editFormData, mailingAddress })}
+                />
+              </Collapse>
             </Box>
           </DialogContent>
           <DialogActions sx={{ px: 3, pb: 3 }}>

--- a/frontend/src/utils/address.js
+++ b/frontend/src/utils/address.js
@@ -1,0 +1,35 @@
+export const EMPTY_ADDRESS = {
+  recipientName: '',
+  line1: '',
+  line2: '',
+  city: '',
+  state: '',
+  postalCode: '',
+  country: '',
+};
+
+export function hasMailingAddress(address) {
+  if (!address) return false;
+  return Object.values(address).some((v) => typeof v === 'string' && v.trim().length > 0);
+}
+
+export function formatMailingAddress(address) {
+  if (!hasMailingAddress(address)) return null;
+
+  const lines = [];
+  const trim = (v) => (typeof v === 'string' ? v.trim() : '');
+
+  if (trim(address.recipientName)) lines.push(trim(address.recipientName));
+  if (trim(address.line1)) lines.push(trim(address.line1));
+  if (trim(address.line2)) lines.push(trim(address.line2));
+
+  const cityStateZip = [trim(address.city), trim(address.state)]
+    .filter(Boolean)
+    .join(', ');
+  const withZip = [cityStateZip, trim(address.postalCode)].filter(Boolean).join(' ');
+  if (withZip) lines.push(withZip);
+
+  if (trim(address.country)) lines.push(trim(address.country));
+
+  return lines;
+}


### PR DESCRIPTION
## Summary
- Add an optional mailing address (recipient, lines, city/state/zip, country) to the Wishlist schema and to POST/PUT `/api/lists`
- Surface a "SHIP GIFTS TO" card on the wishlist page and public invite page when an address is set
- Add a disclosure toggle in the list create/edit dialog so the fields stay out of the way for lists that don't need them

## Test plan
- [x] `npm test` in backend (3 new lists.test cases pass: create-with-address, update + read by shared user, clear-on-empty)
- [ ] Local: create a list with an address, confirm card renders on /lists/:id
- [ ] Local: open the same list via an invite link, confirm card renders
- [ ] Local: edit a list, clear all address fields, save, confirm card disappears