### PR TITLE
Redirect apex giftguru.cc to www

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,3 +1,34 @@
+# Redirect apex (giftguru.cc) -> www.giftguru.cc so there's a single canonical host
+resource "aws_cloudfront_function" "redirect_apex" {
+  name    = "${var.app_name}-redirect-apex-${var.environment}"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<-EOT
+    function handler(event) {
+      var req = event.request;
+      var host = req.headers.host && req.headers.host.value;
+      if (host === 'giftguru.cc') {
+        var qs = '';
+        if (req.querystring) {
+          var parts = [];
+          for (var k in req.querystring) {
+            parts.push(k + '=' + req.querystring[k].value);
+          }
+          if (parts.length) qs = '?' + parts.join('&');
+        }
+        return {
+          statusCode: 301,
+          statusDescription: 'Moved Permanently',
+          headers: {
+            location: { value: 'https://www.giftguru.cc' + req.uri + qs }
+          }
+        };
+      }
+      return req;
+    }
+  EOT
+}
+
 # Origin Access Control for S3
 resource "aws_cloudfront_origin_access_control" "main" {
   name                              = "${var.app_name}-s3-oac-${var.environment}"
@@ -14,7 +45,7 @@ resource "aws_cloudfront_distribution" "main" {
   comment             = "${var.app_name} - ${var.environment}"
   default_root_object = "index.html"
   price_class         = "PriceClass_100" # US, Canada, Europe
-  aliases             = ["www.giftguru.cc"]
+  aliases             = ["giftguru.cc", "www.giftguru.cc"]
 
   # S3 origin for static frontend
   origin {
@@ -62,6 +93,11 @@ resource "aws_cloudfront_distribution" "main" {
       cookies {
         forward = "none"
       }
+    }
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.redirect_apex.arn
     }
 
     min_ttl     = 0


### PR DESCRIPTION
## Summary
- Add `giftguru.cc` to the CloudFront distribution aliases so the apex stops failing the SNI handshake.
- Add a CloudFront Function on viewer-request that 301s `giftguru.cc` to `https://www.giftguru.cc`, preserving path and querystring, so there's a single canonical host.

The existing ACM cert already covers both `giftguru.cc` and `*.giftguru.cc`, so no cert changes are needed. After `terraform apply`, also verify the apex `@` record in Namecheap is an ALIAS pointing to `dyj0kkl9ce0vy.cloudfront.net` (not hard-coded CloudFront IPs).

Closes #21

## Test plan
- [ ] `terraform plan` shows alias addition + new CloudFront Function + association on default behavior, no other diffs
- [ ] `terraform apply`
- [ ] `curl -sI https://giftguru.cc` returns 301 with `location: https://www.giftguru.cc/`
- [ ] `curl -sI https://giftguru.cc/lists?foo=bar` redirects to `https://www.giftguru.cc/lists?foo=bar`
- [ ] `https://www.giftguru.cc` still loads the app
- [ ] OAuth login still works end to end