### PR TITLE
Run terraform plan on PRs and apply on deploy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,26 +118,28 @@ it('should call mongoose save method', ...)
 
 ### Deployment
 
-**Important**: Infrastructure must be deployed before the application. Follow this order:
-
-1. **First, deploy infrastructure (Terraform)**:
-```bash
-cd terraform
-terraform init      # Initialize Terraform (first time only)
-terraform plan      # Review infrastructure changes
-terraform apply     # Apply infrastructure changes (confirm when prompted)
-```
-
-2. **Then, deploy the application** via GitHub Actions:
-
 A push to `main` runs `.github/workflows/deploy.yml`, which path-filters
-backend and frontend so only the changed component deploys. To trigger a
-manual deploy, use Actions → Deploy → Run workflow and choose
-`both` / `backend` / `frontend`.
+`terraform/`, `backend/`, and `frontend/` so only the changed components
+deploy. Terraform applies first, then backend and frontend run in parallel.
+To trigger a manual deploy, use Actions → Deploy → Run workflow and choose
+`all` / `backend` / `frontend` / `terraform`.
+
+PRs that touch `terraform/` get a `terraform plan` posted as a sticky
+comment via `.github/workflows/test.yml`.
 
 The workflow authenticates to AWS via OIDC (`terraform/github_oidc.tf`).
-After `terraform apply`, set these as repo Variables: `AWS_DEPLOY_ROLE_ARN`,
+The deploy role has broad infra perms (it runs `terraform apply`), and its
+trust policy accepts any ref on this repo so the plan job works on PR
+branches. Repo Variables required: `AWS_DEPLOY_ROLE_ARN`,
 `FRONTEND_S3_BUCKET`, `CLOUDFRONT_DISTRIBUTION_ID`.
+
+To run Terraform locally instead:
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
 
 ### Infrastructure (Terraform)
 ```bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ on:
       target:
         description: Which component to deploy
         required: true
-        default: both
+        default: all
         type: choice
-        options: [both, backend, frontend]
+        options: [all, backend, frontend, terraform]
 
 permissions:
   id-token: write
@@ -33,6 +33,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      terraform: ${{ steps.filter.outputs.terraform }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -43,13 +44,45 @@ jobs:
               - 'backend/**'
             frontend:
               - 'frontend/**'
+            terraform:
+              - 'terraform/**'
+
+  terraform:
+    name: Terraform apply
+    needs: changes
+    if: |
+      (github.event_name == 'push' && needs.changes.outputs.terraform == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'terraform'))
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+          terraform_wrapper: false
+
+      - run: terraform init -input=false
+
+      - run: terraform apply -auto-approve -input=false
 
   backend:
     name: Backend (ECR + ECS)
-    needs: changes
+    needs: [changes, terraform]
     if: |
-      (github.event_name == 'push' && needs.changes.outputs.backend == 'true') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'backend'))
+      always() &&
+      needs.terraform.result != 'failure' &&
+      needs.terraform.result != 'cancelled' &&
+      ((github.event_name == 'push' && needs.changes.outputs.backend == 'true') ||
+       (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'backend')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,10 +126,13 @@ jobs:
 
   frontend:
     name: Frontend (S3 + CloudFront)
-    needs: changes
+    needs: [changes, terraform]
     if: |
-      (github.event_name == 'push' && needs.changes.outputs.frontend == 'true') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'frontend'))
+      always() &&
+      needs.terraform.result != 'failure' &&
+      needs.terraform.result != 'cancelled' &&
+      ((github.event_name == 'push' && needs.changes.outputs.frontend == 'true') ||
+       (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'frontend')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,9 @@ jobs:
     defaults:
       run:
         working-directory: terraform
+    env:
+      TF_VAR_ssl_certificate_arn: ${{ vars.SSL_CERTIFICATE_ARN }}
+      TF_VAR_cloudfront_secret: ${{ secrets.CLOUDFRONT_SECRET }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,6 @@ jobs:
         continue-on-error: true
 
       - name: Comment plan on PR
-        if: steps.plan.outputs.exitcode != '0'
         uses: actions/github-script@v7
         env:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
@@ -108,17 +107,27 @@ jobs:
         with:
           script: |
             const exit = process.env.PLAN_EXIT;
-            const failed = exit === '1';
-            const header = failed ? '### Terraform plan failed' : '### Terraform plan';
             const fmtNote = process.env.FMT_EXIT === 'failure'
               ? '\n> `terraform fmt` found formatting issues. Run `terraform fmt -recursive` locally.\n'
               : '';
-            const body = process.env.PLAN_STDOUT || process.env.PLAN_STDERR || '(no output)';
+            let header, body;
+            if (exit === '0') {
+              header = '### Terraform plan: no changes';
+              body = 'Infrastructure matches the configuration.';
+            } else if (exit === '2') {
+              header = '### Terraform plan';
+              body = process.env.PLAN_STDOUT || '(no output)';
+            } else {
+              header = '### Terraform plan failed';
+              body = process.env.PLAN_STDERR || process.env.PLAN_STDOUT || '(no output)';
+            }
             const truncated = body.length > 60000
               ? body.slice(0, 60000) + '\n\n... (truncated, see Actions log for full plan)'
               : body;
             const marker = '<!-- terraform-plan-comment -->';
-            const comment = `${marker}\n${header}${fmtNote}\n\n\`\`\`hcl\n${truncated}\n\`\`\``;
+            const comment = exit === '0'
+              ? `${marker}\n${header}${fmtNote}\n\n${truncated}`
+              : `${marker}\n${header}${fmtNote}\n\n\`\`\`hcl\n${truncated}\n\`\`\``;
 
             const { data: existing } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,26 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      terraform: ${{ steps.filter.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
+
   backend:
     name: Backend tests
     runs-on: ubuntu-latest
@@ -41,3 +60,85 @@ jobs:
 
       - run: npm ci
       - run: CI=true npm run build
+
+  terraform-plan:
+    name: Terraform plan
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.terraform == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+          terraform_wrapper: true
+
+      - run: terraform fmt -check -recursive
+        continue-on-error: true
+        id: fmt
+
+      - run: terraform init -input=false
+
+      - run: terraform validate -no-color
+
+      - id: plan
+        run: terraform plan -no-color -input=false -detailed-exitcode -out=tfplan
+        continue-on-error: true
+
+      - name: Comment plan on PR
+        if: steps.plan.outputs.exitcode != '0'
+        uses: actions/github-script@v7
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_STDERR: ${{ steps.plan.outputs.stderr }}
+          PLAN_EXIT: ${{ steps.plan.outputs.exitcode }}
+          FMT_EXIT: ${{ steps.fmt.outcome }}
+        with:
+          script: |
+            const exit = process.env.PLAN_EXIT;
+            const failed = exit === '1';
+            const header = failed ? '### Terraform plan failed' : '### Terraform plan';
+            const fmtNote = process.env.FMT_EXIT === 'failure'
+              ? '\n> `terraform fmt` found formatting issues. Run `terraform fmt -recursive` locally.\n'
+              : '';
+            const body = process.env.PLAN_STDOUT || process.env.PLAN_STDERR || '(no output)';
+            const truncated = body.length > 60000
+              ? body.slice(0, 60000) + '\n\n... (truncated, see Actions log for full plan)'
+              : body;
+            const marker = '<!-- terraform-plan-comment -->';
+            const comment = `${marker}\n${header}${fmtNote}\n\n\`\`\`hcl\n${truncated}\n\`\`\``;
+
+            const { data: existing } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const prior = existing.find(c => c.body && c.body.includes(marker));
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
+
+      - name: Fail job if plan errored
+        if: steps.plan.outputs.exitcode == '1'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,9 @@ jobs:
     defaults:
       run:
         working-directory: terraform
+    env:
+      TF_VAR_ssl_certificate_arn: ${{ vars.SSL_CERTIFICATE_ARN }}
+      TF_VAR_cloudfront_secret: ${{ secrets.CLOUDFRONT_SECRET }}
     steps:
       - uses: actions/checkout@v4
 

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -30,4 +30,4 @@ resource "aws_ecr_lifecycle_policy" "backend_policy" {
       }
     }]
   })
-} 
+}

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -29,7 +29,9 @@ resource "aws_iam_role" "github_actions_deploy" {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           }
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:ref:refs/heads/main"
+            # Any ref (branches, PRs, tags) on this repo can assume the role.
+            # Apply steps in workflows are gated by event/branch, not by IAM.
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
           }
         }
       }
@@ -37,6 +39,11 @@ resource "aws_iam_role" "github_actions_deploy" {
   })
 }
 
+# Broad infra-management policy. The role is used by the deploy workflow to
+# (a) run `terraform apply` against everything in this directory and
+# (b) push images, sync the frontend bucket, and roll the ECS service.
+# Permissions are scoped by service, not by resource ARN, because Terraform
+# needs to create/destroy arbitrary resources within these services.
 resource "aws_iam_role_policy" "github_actions_deploy" {
   name = "${var.app_name}-github-actions-deploy-${var.environment}"
   role = aws_iam_role.github_actions_deploy.id
@@ -45,63 +52,27 @@ resource "aws_iam_role_policy" "github_actions_deploy" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "EcrAuth"
-        Effect   = "Allow"
-        Action   = "ecr:GetAuthorizationToken"
+        Sid    = "TerraformInfra"
+        Effect = "Allow"
+        Action = [
+          "ec2:*",
+          "elasticloadbalancing:*",
+          "ecs:*",
+          "ecr:*",
+          "iam:*",
+          "logs:*",
+          "cloudfront:*",
+          "acm:*",
+          "s3:*",
+          "route53:*",
+          "resource-groups:*",
+          "tag:*",
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath",
+          "sts:GetCallerIdentity"
+        ]
         Resource = "*"
-      },
-      {
-        Sid    = "EcrPushPull"
-        Effect = "Allow"
-        Action = [
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:BatchGetImage",
-          "ecr:CompleteLayerUpload",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:InitiateLayerUpload",
-          "ecr:PutImage",
-          "ecr:UploadLayerPart"
-        ]
-        Resource = aws_ecr_repository.backend.arn
-      },
-      {
-        Sid    = "EcsDeploy"
-        Effect = "Allow"
-        Action = [
-          "ecs:UpdateService",
-          "ecs:DescribeServices"
-        ]
-        Resource = aws_ecs_service.backend.id
-      },
-      {
-        Sid    = "EcsPassRole"
-        Effect = "Allow"
-        Action = "iam:PassRole"
-        Resource = [
-          aws_iam_role.ecs_task_execution_role.arn,
-          aws_iam_role.ecs_task_role.arn
-        ]
-      },
-      {
-        Sid    = "S3FrontendSync"
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket",
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:PutObjectAcl"
-        ]
-        Resource = [
-          aws_s3_bucket.frontend.arn,
-          "${aws_s3_bucket.frontend.arn}/*"
-        ]
-      },
-      {
-        Sid      = "CloudFrontInvalidate"
-        Effect   = "Allow"
-        Action   = "cloudfront:CreateInvalidation"
-        Resource = aws_cloudfront_distribution.main.arn
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Broaden the GitHub OIDC role to manage all infra services and accept any ref so PR branches can run `terraform plan`
- Add a sticky PR comment with the plan output when `terraform/**` changes
- Run `terraform apply` ahead of backend and frontend in the deploy workflow, gated on path changes or dispatch input

## Test plan
- [ ] PR plan job succeeds and posts a comment showing no drift
- [ ] On merge, deploy workflow's `terraform` job runs and is a no-op (no diff)
- [ ] Backend and frontend jobs run as before when their paths change
- [ ] Manual dispatch with `target=terraform` runs only the terraform job